### PR TITLE
Add ansible_group resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ resource "ansible_host" "example" {
         ansible_user = "admin"
     }
 }
+
+resource "ansible_group" "web" {
+  inventory_group_name = "web"
+  children = ["foo", "bar", "baz"]
+  vars {
+    foo = "bar"
+    bar = 2
+  }
+}
 ```
 
 ## Alternatives and Similar Projects

--- a/ansible/provider.go
+++ b/ansible/provider.go
@@ -8,7 +8,8 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"ansible_host": resourceHost(),
+			"ansible_host":  resourceHost(),
+			"ansible_group": resourceGroup(),
 		},
 	}
 }

--- a/ansible/resource_group.go
+++ b/ansible/resource_group.go
@@ -1,0 +1,40 @@
+package ansible
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAnsibleInventoryGroupCreate,
+		Read:   schema.Noop,
+		Update: schema.Noop,
+		Delete: schema.Noop,
+
+		Schema: map[string]*schema.Schema{
+			"inventory_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"children": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+
+			"vars": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAnsibleInventoryGroupCreate(d *schema.ResourceData, _ interface{}) error {
+	d.SetId(d.Get("inventory_group_name").(string))
+	return nil
+}

--- a/ansible/resource_group_test.go
+++ b/ansible/resource_group_test.go
@@ -1,0 +1,41 @@
+package ansible
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAnsibleGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAnsibleGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "id", "group_1"),
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "children.0", "foo"),
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "children.2", "baz"),
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "vars.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "vars.bar", "2"),
+				),
+			},
+		},
+	})
+}
+
+const testAnsibleGroupConfig = `
+  resource "ansible_group" "group_1" {
+    inventory_group_name = "group_1"
+    children = ["foo", "bar", "baz"]
+    vars {
+      foo = "bar"
+      bar = 2
+    }
+  }
+`


### PR DESCRIPTION
For #3 

Hi @nbering!

Around a month ago I created https://github.com/jtopjian/terraform-provider-ansible-inventory. My original name for the provider was `terraform-provider-ansibleinventory`. I felt that was clunky and wanted to change it to `terraform-provider-ansible`. That's when I came across your project :smile: 

Our work is practically identical, so I'm happy to defer to your project since it was around first (IMO, the problem being solved here is too niche to have more than one solution). 

I modified my original `ansible_group` resource to fit the style laid out in your `ansible_host` resource. Let me know if you have any questions or would like anything changed.

I also have an Ansible inventory script written in Go [here](https://github.com/jtopjian/terraform-provider-ansible-inventory/tree/master/inventory). I will break that out into its own repository and modify it to be compatible with this repo.