### PR TITLE
Missed this test during 0.12 updates.

### DIFF
--- a/ansible/resource_group_test.go
+++ b/ansible/resource_group_test.go
@@ -33,7 +33,7 @@ const testAnsibleGroupConfig = `
   resource "ansible_group" "group_1" {
     inventory_group_name = "group_1"
     children = ["foo", "bar", "baz"]
-    vars {
+    vars = {
       foo = "bar"
       bar = 2
     }


### PR DESCRIPTION
Adds the `=` sign for host `vars` assignment. Looks like I missed this because it had been a while and I forgot to run `make testacc`, forgetting that `make test` doesn't actually run the unit tests.