### PR TITLE
Add support for separate resources to assign individual host or group vars.

### DIFF
--- a/ansible/provider.go
+++ b/ansible/provider.go
@@ -8,8 +8,9 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"ansible_host":  resourceHost(),
-			"ansible_group": resourceGroup(),
+			"ansible_host":     resourceHost(),
+			"ansible_host_var": resourceHostVar(),
+			"ansible_group":    resourceGroup(),
 		},
 	}
 }

--- a/ansible/provider.go
+++ b/ansible/provider.go
@@ -8,9 +8,10 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"ansible_host":     resourceHost(),
-			"ansible_host_var": resourceHostVar(),
-			"ansible_group":    resourceGroup(),
+			"ansible_host":      resourceHost(),
+			"ansible_host_var":  resourceHostVar(),
+			"ansible_group":     resourceGroup(),
+			"ansible_group_var": resourceGroupVar(),
 		},
 	}
 }

--- a/ansible/resource_group_var.go
+++ b/ansible/resource_group_var.go
@@ -1,0 +1,40 @@
+package ansible
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGroupVar() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAnsibleGroupVarCreate,
+		Read:   schema.Noop,
+		Update: schema.Noop,
+		Delete: schema.Noop,
+
+		Schema: map[string]*schema.Schema{
+			"inventory_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAnsibleGroupVarCreate(d *schema.ResourceData, _ interface{}) error {
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("inventory_group_name"), d.Get("key")))
+	return nil
+}

--- a/ansible/resource_group_var_test.go
+++ b/ansible/resource_group_var_test.go
@@ -1,0 +1,36 @@
+package ansible
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAnsibleGroupVar(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAnsibleGroupVarConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ansible_group_var.groupvar_1", "id", "web/baz"),
+					resource.TestCheckResourceAttr(
+						"ansible_group_var.groupvar_1", "inventory_group_name", "web"),
+					resource.TestCheckResourceAttr(
+						"ansible_group_var.groupvar_1", "key", "baz"),
+					resource.TestCheckResourceAttr(
+						"ansible_group_var.groupvar_1", "value", "bup"),
+				),
+			},
+		},
+	})
+}
+
+const testAnsibleGroupVarConfig = `
+  resource "ansible_group_var" "groupvar_1" {
+	  inventory_group_name = "web"
+	  key                  = "baz"
+	  value                = "bup"
+  }
+`

--- a/ansible/resource_host_var.go
+++ b/ansible/resource_host_var.go
@@ -1,0 +1,40 @@
+package ansible
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceHostVar() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAnsibleHostVarCreate,
+		Read:   schema.Noop,
+		Update: schema.Noop,
+		Delete: schema.Noop,
+
+		Schema: map[string]*schema.Schema{
+			"inventory_hostname": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAnsibleHostVarCreate(d *schema.ResourceData, _ interface{}) error {
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("inventory_hostname"), d.Get("key")))
+	return nil
+}

--- a/ansible/resource_host_var_test.go
+++ b/ansible/resource_host_var_test.go
@@ -1,0 +1,36 @@
+package ansible
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAnsibleHostVar(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAnsibleHostVarConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"ansible_host_var.hostvar_1", "id", "www.example.com/foo"),
+					resource.TestCheckResourceAttr(
+						"ansible_host_var.hostvar_1", "inventory_hostname", "www.example.com"),
+					resource.TestCheckResourceAttr(
+						"ansible_host_var.hostvar_1", "key", "foo"),
+					resource.TestCheckResourceAttr(
+						"ansible_host_var.hostvar_1", "value", "bar"),
+				),
+			},
+		},
+	})
+}
+
+const testAnsibleHostVarConfig = `
+  resource "ansible_host_var" "hostvar_1" {
+	  inventory_hostname = "www.example.com"
+	  key                = "foo"
+	  value              = "bar"
+  }
+`


### PR DESCRIPTION
Closes #4.

A large portion of this feature will need to be handled in the inventory script, as it will need to be merged into the final inventory json.

A `priority` level may need to be added to the resource to help the inventory script determine value precedence if there are multiple resources with the same `inventory_hostname` and `key`. It would seem reasonable that this could happen when using terraform `module` structures, which can be somewhat inflexible once implemented, and wanting to override a variable in a specific case.