### PR TITLE
Merge priority property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `priority` added to all resources, to be interpreted by inventory script to merge higher priority vars over lower
 
 ## [0.0.5] - 2019-05-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `priority` added to all resources, to be interpreted by inventory script to merge higher priority vars over lower
+- `variable_priority` added to all resources, to be interpreted by inventory script to merge higher priority vars over lower
 
 ## [0.0.5] - 2019-05-20
 ### Added

--- a/ansible/resource_group.go
+++ b/ansible/resource_group.go
@@ -26,7 +26,7 @@ func resourceGroup() *schema.Resource {
 				Optional: true,
 			},
 
-			"priority": {
+			"variable_priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  50,

--- a/ansible/resource_group.go
+++ b/ansible/resource_group.go
@@ -26,6 +26,12 @@ func resourceGroup() *schema.Resource {
 				Optional: true,
 			},
 
+			"priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  50,
+			},
+
 			"vars": {
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/ansible/resource_group_test.go
+++ b/ansible/resource_group_test.go
@@ -23,6 +23,8 @@ func TestAnsibleGroup(t *testing.T) {
 						"ansible_group.group_1", "vars.foo", "bar"),
 					resource.TestCheckResourceAttr(
 						"ansible_group.group_1", "vars.bar", "2"),
+					resource.TestCheckResourceAttr(
+						"ansible_group.group_1", "priority", "50"),
 				),
 			},
 		},

--- a/ansible/resource_group_test.go
+++ b/ansible/resource_group_test.go
@@ -24,7 +24,7 @@ func TestAnsibleGroup(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ansible_group.group_1", "vars.bar", "2"),
 					resource.TestCheckResourceAttr(
-						"ansible_group.group_1", "priority", "50"),
+						"ansible_group.group_1", "variable_priority", "50"),
 				),
 			},
 		},

--- a/ansible/resource_group_var.go
+++ b/ansible/resource_group_var.go
@@ -20,7 +20,7 @@ func resourceGroupVar() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"priority": {
+			"variable_priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  60,

--- a/ansible/resource_group_var.go
+++ b/ansible/resource_group_var.go
@@ -20,6 +20,12 @@ func resourceGroupVar() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
+			},
+
 			"key": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/ansible/resource_group_var_test.go
+++ b/ansible/resource_group_var_test.go
@@ -21,6 +21,8 @@ func TestAnsibleGroupVar(t *testing.T) {
 						"ansible_group_var.groupvar_1", "key", "baz"),
 					resource.TestCheckResourceAttr(
 						"ansible_group_var.groupvar_1", "value", "bup"),
+					resource.TestCheckResourceAttr(
+						"ansible_group_var.groupvar_1", "priority", "60"),
 				),
 			},
 		},

--- a/ansible/resource_group_var_test.go
+++ b/ansible/resource_group_var_test.go
@@ -22,7 +22,7 @@ func TestAnsibleGroupVar(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ansible_group_var.groupvar_1", "value", "bup"),
 					resource.TestCheckResourceAttr(
-						"ansible_group_var.groupvar_1", "priority", "60"),
+						"ansible_group_var.groupvar_1", "variable_priority", "60"),
 				),
 			},
 		},

--- a/ansible/resource_host.go
+++ b/ansible/resource_host.go
@@ -26,7 +26,7 @@ func resourceHost() *schema.Resource {
 				Optional: true,
 			},
 
-			"priority": {
+			"variable_priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  50,

--- a/ansible/resource_host.go
+++ b/ansible/resource_host.go
@@ -17,6 +17,7 @@ func resourceHost() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
 			"groups": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
@@ -24,6 +25,13 @@ func resourceHost() *schema.Resource {
 				},
 				Optional: true,
 			},
+
+			"priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  50,
+			},
+
 			"vars": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/ansible/resource_host_var.go
+++ b/ansible/resource_host_var.go
@@ -20,7 +20,7 @@ func resourceHostVar() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"priority": {
+			"variable_priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  60,

--- a/ansible/resource_host_var.go
+++ b/ansible/resource_host_var.go
@@ -20,6 +20,12 @@ func resourceHostVar() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  60,
+			},
+
 			"key": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/ansible/resource_host_var_test.go
+++ b/ansible/resource_host_var_test.go
@@ -21,6 +21,8 @@ func TestAnsibleHostVar(t *testing.T) {
 						"ansible_host_var.hostvar_1", "key", "foo"),
 					resource.TestCheckResourceAttr(
 						"ansible_host_var.hostvar_1", "value", "bar"),
+					resource.TestCheckResourceAttr(
+						"ansible_host_var.hostvar_1", "priority", "60"),
 				),
 			},
 		},

--- a/ansible/resource_host_var_test.go
+++ b/ansible/resource_host_var_test.go
@@ -22,7 +22,7 @@ func TestAnsibleHostVar(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ansible_host_var.hostvar_1", "value", "bar"),
 					resource.TestCheckResourceAttr(
-						"ansible_host_var.hostvar_1", "priority", "60"),
+						"ansible_host_var.hostvar_1", "variable_priority", "60"),
 				),
 			},
 		},


### PR DESCRIPTION
Related to https://github.com/nbering/terraform-inventory/issues/11.

Adds a priority property, which allows for overlapping variable sources that will take the variable from the correct source.

| Resource | Default |
| --- | --- |
| ansible_host | 50 |
| ansible_group | 50 |
| ansible_host_var | **60** |
| ansible_group_var | **60** |

Since `*_var` resources are more explicit (setting only one variable), I assume most people would prefer they merge on top of the corresponding host or group by default. This behaviour can of course by overriden by setting the `priority` property of an `*_var` resource to a value lower than 50.

The defaults of 50 and 60 are completely arbitrary, but I figured most would use values somewhere between 0 and 100, so I put the defaults near the middle.

```hcl
resource "ansible_host" "www" {
  inventory_hostname = "www.example.com"
  variable_priority  = 50  # Not really necessary, since this is the default.

  vars = {
    foo = "aaa"
    bar = "bbb"
  }
}

resource "ansible_host_var" "override" {
  inventory_hostname = "www.example.com"
  variable_priority  = 60 # Not really necessary, since this is the default.
  key                = "foo"
  value              = "ccc"
}

resource "ansible_host_var" "underride" {
  inventory_hostname = "www.example.com"
  variable_priority  = 40 # Lower than the default for a host resource
  key                = "bar"
  value              = "ddd"
}

resource "ansible_host_var" "extra" {
  inventory_hostname = "www.example.com"
  variable_priority  = 40 # Lower than the default for a host resource
  key                = "baz"
  value              = "eee"
}
```

The output host variables for `www.example.com` from the terraform-inventory script would be as follows:

```yml
foo: ccc  # from ansible_host_var.override
bar: bbb  # from ansible_host.www
baz: eee  # from ansible_host_var.extra
```

The `ansible_host_var.underride` resource has a lower merge priority than the `ansible_host.www` resource with the same `inventory_hostname`... and the variable key was set in `ansible_host.www`, so the value for `foo` in `ansible_host_var.underride` was not used in the output.

As a counter-example, he `ansible_host_var.extra` resource has a lower merge priority than the `ansible_host.www` resource with the same `inventory_hostname`... but the variable key was not set in `ansible_host.www`, so the value for `baz` in `ansible_host_var.extra` _is_ used in the output.